### PR TITLE
fix: $raw_headers 增加 short_name存储原始的queueName

### DIFF
--- a/src/StompClient.php
+++ b/src/StompClient.php
@@ -71,7 +71,9 @@ class StompClient extends Client
         $headers['ack'] = $headers['ack'] ?? 'auto';
         $subscription = $headers['id'];
 
-        $destination = $this->getQueuePath(Enforcer::$_namespace[$this->_configName], $queueName);
+        // 处理 queueName重复生成的问题 当stomp连接断开reconnect的时候 destination会重复生成
+        $raw_headers['short_name'] = $destinationShortName = $headers['short_name'] ?? $queueName;
+        $destination = $this->getQueuePath(Enforcer::$_namespace[$this->_configName], $destinationShortName);
 
         $headers['destination'] = $destination;
 

--- a/src/StompClient.php
+++ b/src/StompClient.php
@@ -72,8 +72,8 @@ class StompClient extends Client
         $subscription = $headers['id'];
 
         // 处理 queueName重复生成的问题 当stomp连接断开reconnect的时候 destination会重复生成
-        $raw_headers['short_name'] = $destinationShortName = $headers['short_name'] ?? $queueName;
-        $destination = $this->getQueuePath(Enforcer::$_namespace[$this->_configName], $destinationShortName);
+        $raw_headers['short_name'] = $queueName = $headers['short_name'] ?? $queueName;
+        $destination = $this->getQueuePath(Enforcer::$_namespace[$this->_configName], $queueName);
 
         $headers['destination'] = $destination;
 


### PR DESCRIPTION
当stomp连接因为网络或其他情况断开连接时,自动重连成功后会重新订阅所有历史订阅,queueName会重复生成,
增加shortName来记录原始的queueName

@weijer 